### PR TITLE
Do not relocate kryo serialization classes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -362,10 +362,6 @@
                                     <shadedPattern>${shadeBase}.org.objenesis</shadedPattern>
                                 </relocation>
                                 <relocation>
-                                    <pattern>com.esotericsoftware</pattern>
-                                    <shadedPattern>${shadeBase}.com.esotericsoftware</shadedPattern>
-                                </relocation>
-                                <relocation>
                                     <pattern>com.codahale.metrics</pattern>
                                     <shadedPattern>${shadeBase}.com.codahale.metrics</shadedPattern>
                                 </relocation>


### PR DESCRIPTION
Kryo framework defines a set of custom annotations and marker
interfaces that allow to define custom serialization. Classes
marked by the relocated interfaces / annotations are not
compatible with the original (non relocated) kryo serialization
framework running on a real Spark cluster.