### PR TITLE
Upgrade spark-core to 2.4.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-core_2.11</artifactId>
-            <version>2.0.2</version>
+            <version>2.4.4</version>
             <exclusions>
                 <!-- Hadoop -->
                 <exclusion>


### PR DESCRIPTION
spark-core 2.0.2 used in this repo is a few years old which lacking of a few classes (e.g MapLongAccumulator) we want to use which introduce in newer version of Spark. The PR upgrade the spark-core to 2.4.4 which is relatively more recent.