### PR TITLE
Upgrade maven shade plugin to 3.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -304,7 +304,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>2.4.2</version>
+                <version>3.2.1</version>
                 <executions>
                     <execution>
                         <phase>package</phase>


### PR DESCRIPTION
maven shade plugin 3.2.1 is required to shade the spark-core 2.4.4