### PR TITLE
[3.4 Upgrade] Upgrade spark dependency to 3.4.0 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,10 +10,10 @@
 
     <groupId>com.facebook.presto.spark</groupId>
     <artifactId>spark-core</artifactId>
-    <version>2.0.2-7-SNAPSHOT</version>
+    <version>3.4.0-1-SNAPSHOT</version>
 
     <name>spark-core</name>
-    <description>Shaded version of Apache Spark 2.x.x for Presto</description>
+    <description>Shaded version of Apache Spark 3.4.0 for Presto</description>
     <url>https://github.com/prestodb/presto-spark-core</url>
 
     <inceptionYear>2019</inceptionYear>
@@ -43,15 +43,15 @@
 
         <shadeBase>com.facebook.presto.spark.\$internal</shadeBase>
 
-        <dep.slf4j.version>1.7.16</dep.slf4j.version>
+        <dep.slf4j.version>1.7.36</dep.slf4j.version>
     </properties>
 
     <dependencies>
 
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-core_2.11</artifactId>
-            <version>2.4.4</version>
+            <artifactId>spark-core_2.12</artifactId>
+            <version>3.4.0</version>
             <exclusions>
                 <!-- Hadoop -->
                 <exclusion>
@@ -165,6 +165,66 @@
                 <exclusion>
                     <groupId>org.slf4j</groupId>
                     <artifactId>jul-to-slf4j</artifactId>
+                </exclusion>
+
+                <!-- Spark 3.4.0 specific exclusions -->
+                
+                <!-- Kubernetes integration -->
+                <exclusion>
+                    <groupId>io.fabric8</groupId>
+                    <artifactId>kubernetes-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.fabric8</groupId>
+                    <artifactId>kubernetes-model-core</artifactId>
+                </exclusion>
+                
+                <!-- Arrow integration -->
+                <exclusion>
+                    <groupId>org.apache.arrow</groupId>
+                    <artifactId>arrow-vector</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.arrow</groupId>
+                    <artifactId>arrow-memory</artifactId>
+                </exclusion>
+                
+                <!-- Delta Lake integration -->
+                <exclusion>
+                    <groupId>io.delta</groupId>
+                    <artifactId>delta-core_2.12</artifactId>
+                </exclusion>
+                
+                <!-- Iceberg integration -->
+                <exclusion>
+                    <groupId>org.apache.iceberg</groupId>
+                    <artifactId>iceberg-spark-runtime-3.4_2.12</artifactId>
+                </exclusion>
+                
+                <!-- Hudi integration -->
+                <exclusion>
+                    <groupId>org.apache.hudi</groupId>
+                    <artifactId>hudi-spark3.4-bundle_2.12</artifactId>
+                </exclusion>
+                
+                <!-- Enhanced security -->
+                <exclusion>
+                    <groupId>org.apache.kerby</groupId>
+                    <artifactId>kerb-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.kerby</groupId>
+                    <artifactId>kerb-client</artifactId>
+                </exclusion>
+                
+                <!-- Enhanced metrics -->
+                <exclusion>
+                    <groupId>io.prometheus</groupId>
+                    <artifactId>simpleclient</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.prometheus</groupId>
+                    <artifactId>simpleclient_dropwizard</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -366,6 +426,24 @@
                                 <relocation>
                                     <pattern>org.apache.xbean</pattern>
                                     <shadedPattern>${shadeBase}.org.apache.xbean</shadedPattern>
+                                </relocation>
+                                
+                                <!-- Spark 3.4.0 specific relocations -->
+                                <relocation>
+                                    <pattern>org.apache.arrow</pattern>
+                                    <shadedPattern>${shadeBase}.org.apache.arrow</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>io.fabric8</pattern>
+                                    <shadedPattern>${shadeBase}.io.fabric8</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>io.prometheus</pattern>
+                                    <shadedPattern>${shadeBase}.io.prometheus</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.kerby</pattern>
+                                    <shadedPattern>${shadeBase}.org.apache.kerby</shadedPattern>
                                 </relocation>
                             </relocations>
                             <filters>


### PR DESCRIPTION
In preparation to run presto-on-spark on spark 3.4, upgrading the dependency here.

New exclusions are focussed on reducing size of shaded jar.

Further reductions are possible, can revisit in a different PR