### PR TITLE
feat: upgrade spark-core from 3.4.1 to 3.5.8 and add OWASP CI scan

### DIFF
--- a/.github/actions/maven-owasp-scan/action.yml
+++ b/.github/actions/maven-owasp-scan/action.yml
@@ -1,0 +1,39 @@
+name: Maven OWASP Dependency Check Scan
+description: Runs OWASP dependency check Maven scan with consistent settings
+inputs:
+  working-directory:
+    description: Working directory for Maven command
+    required: false
+    default: .
+  owasp-version:
+    description: OWASP dependency check plugin version
+    required: false
+    default: 12.1.3
+  data-directory:
+    description: OWASP data directory path
+    required: false
+    default: /tmp/.owasp/dependency-check-data
+
+runs:
+  using: composite
+  steps:
+    - name: Run OWASP dependency check
+      env:
+        OWASP_VERSION: ${{ inputs.owasp-version }}
+        OWASP_DATA_DIRECTORY: ${{ inputs.data-directory }}
+      working-directory: ${{ inputs.working-directory }}
+      shell: bash
+      run: |
+        mvn org.owasp:dependency-check-maven:$OWASP_VERSION:aggregate \
+          -DskipTests \
+          -Dformat=JSON \
+          -DprettyPrint=true \
+          -DfailOnError=false \
+          -DossindexAnalyzerEnabled=true \
+          -DnvdApiAnalyzerEnabled=false \
+          -DnodeAnalyzerEnabled=false \
+          -DassemblyAnalyzerEnabled=false \
+          -DcentralAnalyzerEnabled=false \
+          -DnuspecAnalyzerEnabled=false \
+          -DnvdValidForHours=168 \
+          -DdataDirectory=$OWASP_DATA_DIRECTORY

--- a/.github/actions/maven-owasp-scan/action.yml
+++ b/.github/actions/maven-owasp-scan/action.yml
@@ -24,7 +24,7 @@ runs:
       working-directory: ${{ inputs.working-directory }}
       shell: bash
       run: |
-        mvn org.owasp:dependency-check-maven:$OWASP_VERSION:aggregate \
+        mvn -B org.owasp:dependency-check-maven:$OWASP_VERSION:aggregate \
           -DskipTests \
           -Dformat=JSON \
           -DprettyPrint=true \

--- a/.github/workflows/owasp-dependency-check.yml
+++ b/.github/workflows/owasp-dependency-check.yml
@@ -1,0 +1,164 @@
+name: Maven OWASP Dependency Check
+permissions:
+  contents: read
+on:
+  pull_request: {}
+  workflow_dispatch:
+    inputs:
+      cvss-threshold:
+        description: CVSS score threshold for failing (7.0 = high/critical)
+        required: false
+        default: '7.0'
+        type: string
+
+jobs:
+  dependency-check:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-owasp-dependency-check-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    env:
+      CVSS_THRESHOLD: ${{ github.event.inputs.cvss-threshold || '0.1' }}
+      OWASP_VERSION: 12.1.3
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Find merge base
+        id: merge-base
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          REPO: ${{ github.repository }}
+        run: |
+          merge_base=$(gh api -q '.merge_base_commit.sha' \
+            "/repos/$REPO/compare/$BASE_REF...$HEAD_SHA")
+          echo "sha=$merge_base" >> $GITHUB_OUTPUT
+          echo "Using merge base: $merge_base"
+
+      - name: Checkout base branch
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          ref: ${{ steps.merge-base.outputs.sha }}
+          path: base
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+          cache: maven
+
+      - name: Get date for cache key
+        id: get-date
+        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+
+      - name: Restore OWASP database cache
+        uses: actions/cache/restore@v4
+        id: cache-owasp-restore
+        with:
+          path: /tmp/.owasp/dependency-check-data
+          key: owasp-cache-${{ runner.os }}-v${{ env.OWASP_VERSION }}-${{ steps.get-date.outputs.date }}
+          restore-keys: |
+            owasp-cache-${{ runner.os }}-v${{ env.OWASP_VERSION }}-
+            owasp-cache-${{ runner.os }}-
+
+      - name: Run OWASP check on base branch
+        uses: ./.github/actions/maven-owasp-scan
+        with:
+          working-directory: base
+          owasp-version: ${{ env.OWASP_VERSION }}
+          data-directory: /tmp/.owasp/dependency-check-data
+
+      - name: Save OWASP cache after base scan
+        if: steps.cache-owasp-restore.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: /tmp/.owasp/dependency-check-data
+          key: owasp-cache-${{ runner.os }}-v${{ env.OWASP_VERSION }}-${{ steps.get-date.outputs.date }}-partial
+
+      - name: Run OWASP check on PR branch
+        uses: ./.github/actions/maven-owasp-scan
+        with:
+          working-directory: .
+          owasp-version: ${{ env.OWASP_VERSION }}
+          data-directory: /tmp/.owasp/dependency-check-data
+
+      - name: Compare and fail on new CVEs above threshold
+        run: |
+          threshold=$CVSS_THRESHOLD
+
+          if [ ! -f base/target/dependency-check-report.json ]; then
+            echo "❌ Missing base report: base/target/dependency-check-report.json"
+            exit 1
+          fi
+          if [ ! -f target/dependency-check-report.json ]; then
+            echo "❌ Missing PR report: target/dependency-check-report.json"
+            exit 1
+          fi
+
+          if ! jq empty base/target/dependency-check-report.json >/dev/null 2>&1; then
+            echo "❌ Malformed JSON in base/target/dependency-check-report.json"
+            exit 1
+          fi
+          if ! jq empty target/dependency-check-report.json >/dev/null 2>&1; then
+            echo "❌ Malformed JSON in target/dependency-check-report.json"
+            exit 1
+          fi
+
+          base_cves=$(jq -r ".dependencies[].vulnerabilities[]? | select((.cvssv2.score // 0) >= $threshold or (.cvssv3.baseScore // 0) >= $threshold) | .name" base/target/dependency-check-report.json | grep -E '^CVE-[0-9]{4}-[0-9]+$' | sort -u)
+          pr_cves=$(jq -r ".dependencies[].vulnerabilities[]? | select((.cvssv2.score // 0) >= $threshold or (.cvssv3.baseScore // 0) >= $threshold) | .name" target/dependency-check-report.json | grep -E '^CVE-[0-9]{4}-[0-9]+$' | sort -u)
+
+          new_cves=$(comm -13 <(echo "$base_cves") <(echo "$pr_cves"))
+
+          if [ -n "$new_cves" ]; then
+            echo "❌ New vulnerabilities with CVSS >= $threshold introduced in PR:"
+            echo "$new_cves"
+            echo ""
+
+            for cve in $new_cves; do
+              echo "=================================================="
+              echo "CVE: $cve"
+              echo "=================================================="
+
+              jq -r '
+                .dependencies[]
+                | select(.vulnerabilities[]?.name == "'"$cve"'")
+                | "Module: " + (.projectReferences // ["root"])[0]
+                  + "\nDependency: " + .fileName
+                  + "\nPackage: " + (if .packages and .packages[0] then .packages[0].id else "N/A" end)
+                  + "\nDescription: " + (
+                      [.vulnerabilities[] | select(.name == "'"$cve"'") | .description]
+                      | unique
+                      | join("\nDescription: ")
+                    )
+              ' target/dependency-check-report.json
+
+              echo ""
+            done
+
+            exit 1
+          else
+            echo "✅ No new vulnerabilities introduced"
+          fi
+
+      - name: Save OWASP database cache
+        if: always()
+        uses: actions/cache/save@v4
+        with:
+          path: /tmp/.owasp/dependency-check-data
+          key: owasp-cache-${{ runner.os }}-v${{ env.OWASP_VERSION }}-${{ steps.get-date.outputs.date }}
+
+      - name: Upload reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: owasp-reports
+          path: |
+            base/target/dependency-check-report.json
+            target/dependency-check-report.json

--- a/pom.xml
+++ b/pom.xml
@@ -10,10 +10,10 @@
 
     <groupId>com.facebook.presto.spark</groupId>
     <artifactId>spark-core</artifactId>
-    <version>3.4.1-3-SNAPSHOT</version>
+    <version>3.5.8-1-SNAPSHOT</version>
 
     <name>spark-core</name>
-    <description>Shaded version of Apache Spark 3.4.1 for Presto</description>
+    <description>Shaded version of Apache Spark 3.5.8 for Presto</description>
     <url>https://github.com/prestodb/presto-spark-core</url>
 
     <inceptionYear>2019</inceptionYear>
@@ -48,15 +48,28 @@
         <shadeBase>com.facebook.presto.spark.\$internal</shadeBase>
 
         <dep.slf4j.version>2.0.6</dep.slf4j.version>
+        <dep.netty.version>4.1.118.Final</dep.netty.version>
         <dep.central-publishing.version>0.8.0</dep.central-publishing.version>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-bom</artifactId>
+                <version>${dep.netty.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
 
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-core_2.13</artifactId>
-            <version>3.4.1</version>
+            <version>3.5.8</version>
             <exclusions>
                 <!-- Hadoop -->
                 <exclusion>
@@ -205,7 +218,25 @@
                     <groupId>io.airlift</groupId>
                     <artifactId>concurrent</artifactId>
                 </exclusion>
-                <!-- Spark 3.4.1 specific exclusions -->
+                <!-- Spark 3.5.8 specific exclusions -->
+
+                <!-- Logging (log4j 2.x via spark-common-utils) -->
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-slf4j2-impl</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-1.2-api</artifactId>
+                </exclusion>
 
                 <!-- Kubernetes integration -->
                 <exclusion>
@@ -230,19 +261,19 @@
                 <!-- Delta Lake integration -->
                 <exclusion>
                     <groupId>io.delta</groupId>
-                    <artifactId>delta-core_2.13</artifactId>
+                    <artifactId>delta-spark_2.13</artifactId>
                 </exclusion>
 
                 <!-- Iceberg integration -->
                 <exclusion>
                     <groupId>org.apache.iceberg</groupId>
-                    <artifactId>iceberg-spark-runtime-3.4_2.13</artifactId>
+                    <artifactId>iceberg-spark-runtime-3.5_2.13</artifactId>
                 </exclusion>
 
                 <!-- Hudi integration -->
                 <exclusion>
                     <groupId>org.apache.hudi</groupId>
-                    <artifactId>hudi-spark3.4-bundle_2.13</artifactId>
+                    <artifactId>hudi-spark3.5-bundle_2.13</artifactId>
                 </exclusion>
 
                 <!-- Enhanced security -->
@@ -466,7 +497,7 @@
                                     <shadedPattern>${shadeBase}.org.apache.xbean</shadedPattern>
                                 </relocation>
 
-                                <!-- Spark 3.4.1 specific relocations -->
+                                <!-- Spark 3.5.8 specific relocations -->
                                 <relocation>
                                     <pattern>org.apache.arrow</pattern>
                                     <shadedPattern>${shadeBase}.org.apache.arrow</shadedPattern>


### PR DESCRIPTION
Upgrade Apache Spark dependency from 3.4.1 to 3.5.8 to resolve CVE-2022-31129 (moment.js ReDoS via vis-timeline bundled in Spark UI).

Spark 3.5 changes reflected:
- Add log4j 2.x exclusions (Spark moved logging to spark-common-utils)
- Rename delta-core_2.13 -> delta-spark_2.13
- Rename iceberg-spark-runtime-3.4_2.13 -> 3.5
- Rename hudi-spark3.4-bundle_2.13 -> 3.5

Add Maven OWASP dependency check workflow to catch new CVEs on PRs.